### PR TITLE
Override language to JavaScript

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.css linguist-language=JavaScript


### PR DESCRIPTION
Github linguist tool detects repo language based on highest lines of code in a language, in the case of this repo, CSS dominates. So since this app is a JS application, forcing the linguist tool to see all CSS code as JS and making the repo a JS based repo.

Signed-off-by: Alangi Derick <alangiderick@gmail.com>